### PR TITLE
* Correção de exp em renovação.

### DIFF
--- a/sql/renovacao/upgrades/2015-09-21--17-18.sql
+++ b/sql/renovacao/upgrades/2015-09-21--17-18.sql
@@ -1,0 +1,38 @@
+/* Exp de Base */
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(151,98000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(152,103000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(153,107000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(154,112000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(155,116000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(156,121000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(157,125000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(158,130000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(159,134000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(160,139000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(161,145000000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(162,152200000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(163,160840000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(164,171200000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(165,191930000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(166,202290000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(167,214720000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(168,229640000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(169,247550000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(170,283370000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(171,301280000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(172,322770000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(173,348560000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(174,379500000);
+INSERT INTO `expparameter3` (`Level`, `exp`) VALUES(175,441390000);
+/* Exp de Trabalho */
+INSERT INTO `thirdjobexpparameter` (`Level`, `exp`) VALUES(51,131668000);
+INSERT INTO `thirdjobexpparameter` (`Level`, `exp`) VALUES(52,145518000);
+INSERT INTO `thirdjobexpparameter` (`Level`, `exp`) VALUES(53,160753000);
+INSERT INTO `thirdjobexpparameter` (`Level`, `exp`) VALUES(54,177511000);
+INSERT INTO `thirdjobexpparameter` (`Level`, `exp`) VALUES(55,195944000);
+INSERT INTO `thirdjobexpparameter` (`Level`, `exp`) VALUES(56,216220000);
+INSERT INTO `thirdjobexpparameter` (`Level`, `exp`) VALUES(57,238523000);
+INSERT INTO `thirdjobexpparameter` (`Level`, `exp`) VALUES(58,263056000);
+INSERT INTO `thirdjobexpparameter` (`Level`, `exp`) VALUES(59,290042000);
+INSERT INTO `thirdjobexpparameter` (`Level`, `exp`) VALUES(60,319726000);
+


### PR DESCRIPTION
A source do emulador está para usar nível de base 175/60 conforme o kRO, mais no banco de dados está com suporte apenas até 150/50, o que iria gerar algumas problemas, pois os atributos estão para valores de 130 que é a quantidade do nível 175.