### PR TITLE
* Correção da versão de packetver do pacote PACKET_ZC_EFST_SET_ENTER

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -17280,6 +17280,7 @@ void clif_maptypeproperty2(struct block_list *bl,enum send_target t) {
 
 // ícone de efeitos [Megasantos]
 void clif_efst_set_enter(struct block_list *bl, int tid, enum send_target target, int type, int val1, int val2, int val3) {
+#if PACKETVER >= 20111101
 	struct PACKET_ZC_EFST_SET_ENTER p;
 
 	p.PacketType = efst_set_enterType;
@@ -17294,6 +17295,7 @@ void clif_efst_set_enter(struct block_list *bl, int tid, enum send_target target
 	p.Val3 = val3;
 
 	clif->send(&p,sizeof(p), bl, target);
+#endif
 }
 
 void clif_partytickack(struct map_session_data* sd, bool flag) {

--- a/src/map/packets_struct.h
+++ b/src/map/packets_struct.h
@@ -57,7 +57,7 @@ enum packet_headers {
 #endif
 #if PACKETVER >= 20120618
 	efst_set_enterType = 0x984,
-#elif PACKETVER >= 20111108
+#elif PACKETVER >= 20111101
 	efst_set_enterType = 0x8ff,
 #endif
 	status_change_endType = 0x196,


### PR DESCRIPTION
O pacote apareceu pela primeira vez no client 2011-11-01, clients abaixo dessa versão não usaram o pacote.