### PR TITLE
* Adicionado comando para relogar loja de cash.

### DIFF
--- a/conf/messages.conf
+++ b/conf/messages.conf
@@ -1538,5 +1538,10 @@
 1498: Você não pode adicionar um item vinculado ao grupo sem que o personagem esteja em algum grupo!
 1499: Você não pode adicionar um item vinculado ao clã sem que o personagem esteja em algum clã!
 
+// Reservado brAthena 3000-4000
+// @reloadcashshop [Megasantos]
+3000: Atenção!! A Loja de Cash foi atualizada, é necessário relogar para comprar itens na Loja de Cash.
+3001: Loja de Cash foi atualizada, relogue para poder comprar itens.
+
 // Traduções personalizadas
 import: conf/import/msg_conf.txt

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -486,6 +486,7 @@ struct mmo_charstatus {
 	int father;
 	int mother;
 	int child;
+	bool cash_shop; // Megasantos
 
 	unsigned int base_exp,job_exp;
 	int zeny;

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -9381,6 +9381,23 @@ ACMD(lang) {
 	return true;
 }
 /**
+* Faz uma nova leitura do banco de dados cashshop. [Megasantos]
+**/
+ACMD(reloadcashshop) {
+	struct s_mapiterator* sd_cash = mapit_getallusers();
+
+	for(sd = (TBL_PC*)mapit->first(sd_cash); mapit->exists(sd_cash); sd = (TBL_PC*)mapit->next(sd_cash))
+		sd->status.cash_shop = true;
+
+	intif->broadcast(msg_sd(sd, 3000), strlen(msg_sd(sd, 3000)) + 1, 0);
+	
+	clif_cashshop_db();
+	mapit->free(sd_cash);
+
+	return true;
+}
+
+/**
  * Fills the reference of available commands in atcommand DBMap
  **/
 #define ACMD_DEF(x) { #x, atcommand_ ## x, NULL, NULL, NULL, true }
@@ -9651,6 +9668,7 @@ void atcommand_basecommands(void) {
 		ACMD_DEF(skdebug),
 		ACMD_DEF(cddebug),
 		ACMD_DEF(lang),
+		ACMD_DEF(reloadcashshop), // Megasantos
 	};
 	int i;
 

--- a/src/map/atcommand.h
+++ b/src/map/atcommand.h
@@ -28,7 +28,7 @@ struct block_list;
  * Defines
  **/
 #define ATCOMMAND_LENGTH 50
-#define MAX_MSG 1500
+#define MAX_MSG 4000
 #define msg_txt(idx) atcommand->msg(idx)
 #define msg_sd(sd,msg_number) atcommand->msgsd((sd),(msg_number))
 #define msg_fd(fd,msg_number) atcommand->msgfd((fd),(msg_number))

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -17101,6 +17101,11 @@ void __attribute__ ((unused)) clif_parse_dull(int fd,struct map_session_data *sd
 }
 void clif_parse_CashShopOpen(int fd, struct map_session_data *sd) {
 
+	if(sd->status.cash_shop == true) {
+		clif->messagecolor_self(fd, COLOR_RED, msg_fd(fd, 3001));
+		return;
+	}
+
 	if (map->list[sd->bl.m].flag.nocashshop) {
 		clif->messagecolor_self(fd, COLOR_RED, msg_fd(fd,1489)); //Cash Shop is disabled in this map
 		return;
@@ -17141,6 +17146,11 @@ void clif_parse_CashShopSchedule(int fd, struct map_session_data *sd) {
 void clif_parse_CashShopBuy(int fd, struct map_session_data *sd) {
 	unsigned short limit = RFIFOW(fd, 4), i, j;
 	unsigned int kafra_pay = RFIFOL(fd, 6);// [Ryuuzaki] - These are free cash points (strangely #CASH = main cash currently for us, confusing)
+
+	if(sd->status.cash_shop == true) {
+		clif->messagecolor_self(fd, COLOR_RED, msg_fd(fd, 3001));
+		return;
+	}
 
 	if (map->list[sd->bl.m].flag.nocashshop) {
 		clif->messagecolor_self(fd, COLOR_RED, msg_fd(fd,1489)); //Cash Shop is disabled in this map


### PR DESCRIPTION
Esse comando eu tinha adicionado no antigo emulador, mais nesse novo não chegaram a adicionar, com isso estou adicionando novamente o comando com algumas melhorias, algumas delas são bloquear a compra de itens caso algum jogador estiver realizando compra no exato momento do reload.