### PR TITLE
Correção nas falhas de compilações

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -113,6 +113,7 @@ distclean: clean
 	@-rm -f $(MF_TARGETS) config.status config.log
 
 sysinfo: config.status
+	@chmod 777 sysinfogen.sh
 	@./sysinfogen.sh src/common/sysinfo_new.inc @CFLAGS@ @CPPFLAGS@
 	@if cmp -s src/common/sysinfo.inc src/common/sysinfo_new.inc; then \
 		rm src/common/sysinfo_new.inc ; \


### PR DESCRIPTION
Alguns usuários abrem tópicos desnecessários nos projetos aonde o próprio emulador poderia dar as permissões devidas ao arquivo.
Isso não irá resolver problemas de codificação mas vai resolver os problemas relacionados a permissão no arquivo referido já que tenta rodar diretamente em vez de emulador o shell.