### PR TITLE
correção ao erro no mariadb principal.sql

### DIFF
--- a/sql/principal.sql
+++ b/sql/principal.sql
@@ -837,10 +837,10 @@ CREATE TABLE IF NOT EXISTS `sql_updates` (
   PRIMARY KEY (`timestamp`)
 ) ENGINE=MyISAM;
 
-INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1443394980); -- 2015-09-27--23-03.sql
-INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1440688342); -- 2015-08-27--20-42.sql
-INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1445742780); -- 2015-10-25--03-13.sql
-INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1459870423); -- 2016-04-05--15-33.sql
+INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1443394980);
+INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1440688342);
+INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1445742780);
+INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1459870423);
 
 --
 -- Estrutura da tabela `storage`


### PR DESCRIPTION
Erro
Comando SQL:
INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1443394980); -- 2015-09-27--23-03.sql INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1440688342); -- 2015-08-27--20-42.sql INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1445742780); -- 2015-10-25--03-13.sql INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1459870423); -- 2016-04-05--15-33.sql -- -- Estrutura da tabela `storage` -- CREATE TABLE IF NOT EXISTS `storage` ( `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT, `account_id` INT(11) UNSIGNED NOT NULL DEFAULT '0', `nameid` INT(11) UNSIGNED NOT NULL DEFAULT '0', `amount` SMALLINT(11) UNSIGNED NOT NULL DEFAULT '0', `equip` INT(11) UNSIGNED NOT NULL DEFAULT '0', `identify` SMALLINT(6) UNSIGNED NOT NULL DEFAULT '0', `refine` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0', `attribute` TINYINT(4) UNSIGNED NOT NULL DEFAULT '0', `card0` SMALLINT(11) NOT NULL DEFAULT '0', `card1` SMALLINT(11) NOT NULL DEFAULT '0', `card2` SMA[...]
Mensagens do MySQL : dot.gif
#1064 - You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'INSERT IGNORE INTO `sql_updates` (`timestamp`) VALUES (1440688342); -- 2015-08-2' at line 2