### PR TITLE
Correção do overflow na função visual bg_message

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -16352,7 +16352,7 @@ void clif_bg_message(struct battleground_data *bgd, int src_id, const char *name
 	if (!bgd->count || (sd = bg->getavailablesd(bgd)) == NULL)
 		return;
 
-	len = (int)strlen(mes);
+	len = (int)strlen(mes) + 1;
 	Assert_retv(len <= INT16_MAX - NAME_LENGTH - 8);
 	buf = (unsigned char*)aMalloc((len + NAME_LENGTH + 8)*sizeof(unsigned char));
 


### PR DESCRIPTION
Correção do problema citado no [tópico aberto por mim no fórum](https://forum.brathena.org/index.php?/topic/26774-bug-bg_message/).
Aparentemente ocorria uma fuga de memória na alocação dinâmica. Comparei com versões anteriores do emulador e verifiquei que o tamanho da mensagem era recebido como parâmetro, e que todas as entradas por parâmetro somavam +1 ao tamanho original da string.
Mantive a definição do _length_ dentro da função e incrementei a variável. Realizei os testes e as mensagens agora são exibidas normalmente.